### PR TITLE
pin vultr provider, add test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-cluster.env
+*.env
 .terraform
+terraform.tfstate*

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,0 +1,9 @@
+variable api_key {
+  type = string
+}
+
+module "condor" {
+  source  = "../"
+  cluster_api_key = var.api_key
+  cluster_name = "condor-test"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -8,6 +8,7 @@ terraform {
     }
     vultr = {
       source = "vultr/vultr"
+      version = "1.5.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
Pins the Vultr provider to `v1.5.0`, the v2 Provider breaks this due to changes in resource names and parameters(will need to update this module later). Also added a test tf plan. 