### PR TITLE
Open all on private interface

### DIFF
--- a/scripts/condor-provision.sh
+++ b/scripts/condor-provision.sh
@@ -57,11 +57,13 @@ firewall_config(){
 		controller)
 			for port in "$${CONTROL_PLANE_PORTS[@]}"; do
 				ufw allow $port
+				ufw allow in on ens7
 			done
 			;;
 		worker)
 			ufw allow 10250
 			ufw allow 30000:32767/tcp
+			ufw allow in on ens7
 			;;
 	esac
 


### PR DESCRIPTION
Due to Vultr image changes, in addition to the changes in #40 we also need to open all traffic on the private interface(e.g. CNI/Calico traffic). 